### PR TITLE
Fix the error Nil parameters in the find_routes method.

### DIFF
--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -9,7 +9,9 @@ module ActionDispatchJourneyRouterWithFiltering
     end
 
     super(env).map do |match, parameters, route|
-      [ match, parameters.merge(filter_parameters), route ]
+      params = parameters&.merge(filter_parameters) || {}
+
+      [ match, params, route ]
     end.tap do |match, parameters, route|
       # restore the original path
       if env.is_a?(Hash)

--- a/lib/routing_filter/version.rb
+++ b/lib/routing_filter/version.rb
@@ -1,3 +1,3 @@
 module RoutingFilter
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
## What?

When `parameters`  was nil, the merge wouldn't work. Fixed now.