### PR TITLE
HOTT-4457: Reflect new yielding find_routes api in rails

### DIFF
--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -16,19 +16,25 @@ module ActionDispatchJourneyRouterWithFiltering
     filter_parameters = {}
     original_path = path.dup
 
+    # Apply the custom user around_recognize filter callbacks
     @routes.filters.run(:around_recognize, path, env) do
+      # Yield the filter paramters for adjustment by the user
       filter_parameters
     end
 
+    # Recognize the routes
     super(env) do |match, parameters, route|
+      # Merge in custom parameters that will be visible to the controller
       params = (parameters || {}).merge(filter_parameters)
 
+      # Reset the path before yielding to the controller (prevents breakages in CSRF validation)
       if env.is_a?(Hash)
         env['PATH_INFO'] = original_path
       else
         env.path_info = original_path
       end
 
+      # Yield results are dispatched to the controller
       yield [match, params, route]
     end
   end

--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -1,6 +1,18 @@
+# frozen_string_literal: true
+
+# Prepend the method lookup to intercept find_routes in rails.
+#
+# This enables us to intercept the incoming route paths before they are
+# recognized by the rails router and transformed to a route set and dispatched
+# to a controller.
 module ActionDispatchJourneyRouterWithFiltering
   def find_routes(env)
-    path = env.is_a?(Hash) ? env['PATH_INFO'] : env.path_info
+    path = if env.is_a?(Hash)
+             env['PATH_INFO']
+           else
+             env.path_info
+           end
+
     filter_parameters = {}
     original_path = path.dup
 
@@ -8,19 +20,18 @@ module ActionDispatchJourneyRouterWithFiltering
       filter_parameters
     end
 
-    super(env).map do |match, parameters, route|
+    super(env) do |match, parameters, route|
       params = (parameters || {}).merge(filter_parameters)
 
-      [ match, params, route ]
-    end.tap do |match, parameters, route|
-      # restore the original path
       if env.is_a?(Hash)
         env['PATH_INFO'] = original_path
       else
         env.path_info = original_path
       end
+
+      yield [match, params, route]
     end
   end
 end
 
-ActionDispatch::Journey::Router.send(:prepend, ActionDispatchJourneyRouterWithFiltering)
+ActionDispatch::Journey::Router.prepend(ActionDispatchJourneyRouterWithFiltering)

--- a/lib/routing_filter/version.rb
+++ b/lib/routing_filter/version.rb
@@ -1,3 +1,3 @@
 module RoutingFilter
-  VERSION = '0.7.2'
+  VERSION = '1.0.0'
 end

--- a/routing-filter.gemspec
+++ b/routing-filter.gemspec
@@ -1,17 +1,17 @@
-$:.unshift File.expand_path('../lib', __FILE__)
+$:.unshift File.expand_path('lib', __dir__)
 require 'routing_filter/version'
 
-rails_version = ['>= 6.1']
+rails_version = ['>= 7.1']
 
 Gem::Specification.new do |s|
-  s.name         = "routing-filter"
+  s.name         = 'routing-filter'
   s.version      = RoutingFilter::VERSION
-  s.license      = "MIT"
-  s.authors      = ["Sven Fuchs"]
-  s.email        = "svenfuchs@artweb-design.de"
-  s.homepage     = "http://github.com/svenfuchs/routing-filter"
-  s.summary      = "Routing filters wraps around the complex beast that the Rails routing system is, allowing for unseen flexibility and power in Rails URL recognition and generation"
-  s.description  = "Routing filters wraps around the complex beast that the Rails routing system is, allowing for unseen flexibility and power in Rails URL recognition and generation."
+  s.license      = 'MIT'
+  s.authors      = ['Alessandro De Simone, William Fish, Svend Fuchs']
+  s.email        = 'svenfuchs@artweb-design.de'
+  s.homepage     = 'http://github.com/svenfuchs/routing-filter'
+  s.summary      = 'Routing filters wraps around the complex beast that the Rails routing system is, allowing for unseen flexibility and power in Rails URL recognition and generation'
+  s.description  = 'Routing filters wraps around the complex beast that the Rails routing system is, allowing for unseen flexibility and power in Rails URL recognition and generation.'
 
   s.files        = Dir['CHANGELOG.md', 'README.markdown', 'MIT-LICENSE', 'lib/**/*']
   s.platform     = Gem::Platform::RUBY
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', rails_version
 
   s.add_development_dependency 'i18n'
-  s.add_development_dependency 'test_declarative'
+  s.add_development_dependency 'minitest', '< 5.10.2'
   s.add_development_dependency 'rack-test', '~> 0.6.2'
   s.add_development_dependency 'rails', rails_version
-  s.add_development_dependency 'minitest', '< 5.10.2'
+  s.add_development_dependency 'test_declarative'
 end

--- a/test/filters/all_filters/recognition.rb
+++ b/test/filters/all_filters/recognition.rb
@@ -7,86 +7,86 @@ module Recognition
   end
 
   test 'recognizes the path /de/some (locale)' do
-    params = self.params.merge(:locale => 'de')
+    params = self.params.merge(locale: 'de')
     assert_equal params, routes.recognize_path('/de/some')
   end
 
   test 'recognizes the path /some/page/2 (pagination)' do
-    params = self.params.merge(:page => '2')
+    params = self.params.merge(page: '2')
     assert_equal params, routes.recognize_path('/some/page/2')
   end
 
   test 'recognizes the path /:uuid/some (uuid)' do
-    params = self.params.merge(:uuid => uuid)
+    params = self.params.merge(uuid:)
     assert_equal params, routes.recognize_path("/#{uuid}/some")
   end
 
   # extension with any
 
   test 'recognizes the path /de/some.html (extension, locale)' do
-    params = self.params.merge(:locale => 'de')
+    params = self.params.merge(locale: 'de')
     assert_equal params, routes.recognize_path('/de/some.html')
   end
 
   test 'recognizes the path /some/page/2.html (extension, pagination)' do
-    params = self.params.merge(:page => '2')
+    params = self.params.merge(page: '2')
     assert_equal params, routes.recognize_path('/some/page/2.html')
   end
 
   test 'recognizes the path /:uuid/some.html (extension, uuid)' do
-    params = self.params.merge(:uuid => uuid)
+    params = self.params.merge(uuid:)
     assert_equal params, routes.recognize_path("/#{uuid}/some.html")
   end
 
   # locale with any
 
   test 'recognizes the path /de/some/page/2 (locale, pagination)' do
-    params = self.params.merge(:locale => 'de', :page => '2')
+    params = self.params.merge(locale: 'de', page: '2')
     assert_equal params, routes.recognize_path('/de/some/page/2')
   end
 
   test 'recognizes the path /de/:uuid/some (locale, uuid)' do
-    params = self.params.merge(:locale => 'de', :uuid => uuid)
+    params = self.params.merge(locale: 'de', uuid:)
     assert_equal params, routes.recognize_path("/de/#{uuid}/some")
   end
 
   # pagination with any
 
   test 'recognizes the path /:uuid/some/page/2 (pagination, uuid)' do
-    params = self.params.merge(:page => '2', :uuid => uuid)
+    params = self.params.merge(page: '2', uuid:)
     assert_equal params, routes.recognize_path("/#{uuid}/some/page/2")
   end
 
   # extension, locale with any
 
   test 'recognizes the path /de/some/page/2.html (extension, locale, pagination)' do
-    params = self.params.merge(:locale => 'de', :page => '2')
-    assert_equal params, routes.recognize_path("/de/some/page/2.html")
+    params = self.params.merge(locale: 'de', page: '2')
+    assert_equal params, routes.recognize_path('/de/some/page/2.html')
   end
 
   test 'recognizes the path /de/:uuid/some.html (extension, locale, uuid)' do
-    params = self.params.merge(:locale => 'de', :uuid => uuid)
+    params = self.params.merge(locale: 'de', uuid:)
     assert_equal params, routes.recognize_path("/de/#{uuid}/some.html")
   end
 
   # extension, pagination with any
 
   test 'recognizes the path /some/page/2.html (extension, pagination, uuid)' do
-    params = self.params.merge(:page => '2', :uuid => uuid)
+    params = self.params.merge(page: '2', uuid:)
     assert_equal params, routes.recognize_path("/#{uuid}/some/page/2.html")
   end
 
   # locale, pagination with any
 
   test 'recognizes the path /de/some/page/2 (locale, pagination, uuid)' do
-    params = self.params.merge(:locale => 'de', :page => '2', :uuid => uuid)
+    params = self.params.merge(locale: 'de', page: '2', uuid:)
     assert_equal params, routes.recognize_path("/de/#{uuid}/some/page/2")
   end
 
   # all
 
   test 'recognizes the path /de/:uuid/some/page/2.html (extension, locale, pagination, uuid)' do
-    params = self.params.merge(:locale => 'de', :page => '2', :uuid => uuid)
+    params = self.params.merge(locale: 'de', page: '2', uuid:)
     assert_equal params, routes.recognize_path("/de/#{uuid}/some/page/2.html")
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4457

### What?

I have added/removed/altered:

- [x] Fix the sequence of path resetting in the prepended `find_routes` method

### Why?

I am doing this because:

Rails 7.1.x moved to a yielding api for the internal find_routes method.

This broke our routing filter implementation by forcing us to reset the
path after controller dispatch had happened which was triggering
the forgery protection callback to be invoked with the wrong path.

We can fix this out of sequence issue, by resetting the path info
_before_ we transition to do controller dispatch.

This is essentially what we've done here.
