### PR TITLE
Rails 8.1 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0
+
+* Rails 8.1+ exclusive support (patches `recognize` instead of removed `find_routes`)
+
 ## 0.7.0
 
 * Rails 6.1 exclusive support

--- a/lib/routing_filter/adapters/routers/journey.rb
+++ b/lib/routing_filter/adapters/routers/journey.rb
@@ -1,41 +1,33 @@
 # frozen_string_literal: true
 
-# Prepend the method lookup to intercept find_routes in rails.
+# Prepend the method lookup to intercept route recognition in rails.
 #
 # This enables us to intercept the incoming route paths before they are
 # recognized by the rails router and transformed to a route set and dispatched
 # to a controller.
 module ActionDispatchJourneyRouterWithFiltering
-  def find_routes(env)
-    path = if env.is_a?(Hash)
-             env['PATH_INFO']
-           else
-             env.path_info
-           end
-
-    filter_parameters = {}
+  def recognize(req, &block)
+    path = req.path_info.dup
     original_path = path.dup
+    filter_parameters = {}
 
     # Apply the custom user around_recognize filter callbacks
-    @routes.filters.run(:around_recognize, path, env) do
-      # Yield the filter paramters for adjustment by the user
+    @routes.filters.run(:around_recognize, path, req) do
+      # Yield the filter parameters for adjustment by the user
       filter_parameters
     end
 
+    # Filters mutate path in-place; set it back before super reads req.path_info
+    req.path_info = path
+
     # Recognize the routes
-    super(env) do |match, parameters, route|
+    super(req) do |route, parameters|
       # Merge in custom parameters that will be visible to the controller
-      params = (parameters || {}).merge(filter_parameters)
+      params = parameters.merge(filter_parameters)
 
       # Reset the path before yielding to the controller (prevents breakages in CSRF validation)
-      if env.is_a?(Hash)
-        env['PATH_INFO'] = original_path
-      else
-        env.path_info = original_path
-      end
-
-      # Yield results are dispatched to the controller
-      yield [match, params, route]
+      req.path_info = original_path
+      block.call(route, params)
     end
   end
 end

--- a/routing-filter.gemspec
+++ b/routing-filter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<actionpack>.freeze, [">= 7.1"])
   s.add_runtime_dependency(%q<activesupport>.freeze, [">= 7.1"])
   s.add_development_dependency(%q<i18n>.freeze, [">= 0"])
-  s.add_development_dependency(%q<minitest>.freeze, ["< 5.10.2"])
+  s.add_development_dependency(%q<minitest>.freeze, [">= 5.1"])
   s.add_development_dependency(%q<rack-test>.freeze, ["~> 0.6.2"])
   s.add_development_dependency(%q<rails>.freeze, [">= 7.1"])
   s.add_development_dependency(%q<test_declarative>.freeze, [">= 0"])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ require 'test_adapters/rails'
 
 I18n.enforce_available_locales = false
 
-class MiniTest::Test
+class Minitest::Test
   def draw_routes(&block)
     ActionDispatch::Routing::RouteSet.new.tap { |set| set.draw(&block) }
   end


### PR DESCRIPTION
When working on a Rails upgrade of our other apps [(HMRC-1994)](https://transformuk.atlassian.net/browse/HMRC-1994), I ran into the issue that rails 8.1 removes `#find_routes` completely in favour of `#recognize`.

This PR changes routing filter to patch `#recognize` instead of `#find_routes` to work for >= rails 8.1