### PR TITLE
Cover Rails 8 routing integration

### DIFF
--- a/lib/routing_filter/adapters/rails.rb
+++ b/lib/routing_filter/adapters/rails.rb
@@ -19,11 +19,11 @@ module ActionDispatchRoutingRouteSetWithFiltering
     names.each { |name| filters.unshift(RoutingFilter.build(name, options)) }
   end
 
-  def generate(route_key, options, recall = {})
+  def generate(route_key, options, recall = {}, method_name = nil)
     options = options.symbolize_keys
 
     filters.run(:around_generate, options, &lambda {
-      RoutingFilter::ResultWrapper.new(super(route_key, options, recall))
+      RoutingFilter::ResultWrapper.new(super(route_key, options, recall, method_name))
     }).generate
   end
 

--- a/test/filters/all_filters/generation.rb
+++ b/test/filters/all_filters/generation.rb
@@ -39,4 +39,10 @@ module Generation
     params = self.params.merge(:locale => 'de', :page => 2, :uuid => uuid)
     assert_generates "/de/#{uuid}/some/page/2.html", routes.path_for(params)
   end
+
+  test 'generates the path /de/:uuid/some/page/2.html with named route helpers' do
+    path = routes.url_helpers.some_path(:locale => 'de', :page => 2, :uuid => uuid)
+
+    assert_equal "/de/#{uuid}/some/page/2.html", path
+  end
 end

--- a/test/filters/all_filters_test.rb
+++ b/test/filters/all_filters_test.rb
@@ -17,7 +17,7 @@ class AllFiltersTest < Minitest::Test
 
     @routes = draw_routes do
       filter :uuid, :pagination ,:locale, :extension
-      get 'some', :to => 'some#index'
+      get 'some', :to => 'some#index', :as => :some
     end
   end
 

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -14,6 +14,26 @@ class RoutesTest < Minitest::Test
     end
   end
 
+  class RoutingFilter::NamedHelperLocale < Filter
+    def around_generate(params, &block)
+      locale = params.delete(:locale)
+
+      yield.tap do |result|
+        result.update "/#{locale}#{result.url}" if locale
+      end
+    end
+  end
+
+  class RoutingFilter::RecognitionMarker < Filter
+    def around_recognize(path, env, &block)
+      path.sub!(%r{^/marker}, '')
+
+      yield.tap do |params|
+        params[:marker] = 'yes'
+      end
+    end
+  end
+
   attr_reader :routes
 
   def setup
@@ -33,5 +53,38 @@ class RoutesTest < Minitest::Test
 
   test "filter.around_generate is being called" do
     assert_equal 'generated', routes.path_for({ controller: 'some', action: 'show', id: 1 })
+  end
+
+  test "filter.around_generate is called for named route helpers" do
+    routes = draw_routes do
+      filter :named_helper_locale
+      get 'some', :to => 'some#show', :as => :some
+    end
+
+    assert_equal '/de/some', routes.url_helpers.some_path(locale: 'de')
+  end
+
+  test "route set generate override accepts the current Rails signature" do
+    assert_equal(
+      [[:req, :route_key], [:req, :options], [:opt, :recall], [:opt, :method_name]],
+      ActionDispatchRoutingRouteSetWithFiltering.instance_method(:generate).parameters,
+    )
+  end
+
+  test "journey router recognize applies filters and restores request path info" do
+    routes = draw_routes do
+      filter :recognition_marker
+      get 'some', :to => 'some#show'
+    end
+
+    request = routes.send(:make_request, Rack::MockRequest.env_for('/marker/some'))
+    recognized = []
+
+    routes.router.recognize(request) do |_route, params|
+      recognized << params
+    end
+
+    assert_equal 'yes', recognized.first[:marker]
+    assert_equal '/marker/some', request.path_info
   end
 end


### PR DESCRIPTION
## What

Adds Rails 8.1-focused coverage around routing-filter's Rails integration and updates the route generation override to match Rails' current private `RouteSet#generate` signature.

## Why

The upstream gem is effectively behind this fork, so the useful maintenance path is to make our fork explicit about the Rails APIs it depends on. Rails 8.1 carries a fourth `method_name` argument through route generation; this adapter still accepted the older three-argument signature.

## Changes

- Covers `around_generate` through named route helpers, not just `RouteSet#path_for`.
- Covers the built-in filters together through a named route helper.
- Covers direct `Journey::Router#recognize` behavior and request `path_info` restoration.
- Passes Rails' current `method_name` argument through the adapter's `generate` override.

## Verification

- `nix develop /home/william/Repositories/hmrc/routing-filter -c bundle exec rake test`
- Result: 69 runs, 103 assertions, 0 failures, 0 errors, 0 skips
- Commit-time pre-commit hooks passed.
