### PR TITLE
BAU: Update Nix flake lock

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,40 @@
+name: Auto-merge low-risk PRs
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+      - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
+  workflow_run:
+    workflows:
+      - "ci"
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: >-
+      (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft
+      ) &&
+      (
+        github.event_name != 'pull_request_review' ||
+        github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+      )
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/auto-merge-low-risk.yml@main
+    with:
+      label: low-risk
+      merge-method: rebase
+      required-workflow: ci.yml
+    secrets:
+      github-token: ${{ secrets.PULL_REQUEST_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rake

--- a/flake.lock
+++ b/flake.lock
@@ -50,34 +50,13 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1788982683,
+        "narHash": "sha256-PJCTsE4I20CrJJPcye9/z6brRFysG5+aygr/dZK097k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "5052d7ccbcfb7e4ae1586cb2ecf95a2e3707dce9",
         "type": "github"
       },
       "original": {
@@ -98,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781519518,
-        "narHash": "sha256-5f9Yix1MUsjX+pgsJNNvfoaOUwQEp+MaDttVMLU+bcg=",
+        "lastModified": 1788949264,
+        "narHash": "sha256-IavuDJd3wSs4IB4n2Twe572WNcMDEo1YifTDp6Joj78=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "b217e4bf517b5437d2ffab5faa4432f1f8a0b26f",
+        "rev": "9b5379a94d55586ed1f503f511a89ca270006028",
         "type": "github"
       },
       "original": {
@@ -114,17 +93,16 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1788267358,
+        "narHash": "sha256-nt+lUqYVpc9Y6JeMd2WmXzCDojasdadKo0mWcluvY2Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "27555e2624241fb116b49095df4caaee85a25691",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What:

- [x] Update flake.lock with `nix flake update`

## Why:

Nix flake inputs were behind current upstream revisions. Lockfile-only refresh for the local/dev Nix toolchain.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Dependency lock bump with no application or Terraform source changes.